### PR TITLE
Add test button to header with translations

### DIFF
--- a/app/scripts/controllers/sections/header.js
+++ b/app/scripts/controllers/sections/header.js
@@ -9,7 +9,7 @@
  */
 angular.module('beeOneWebFrontApp')
   .controller('HeaderCtrl', async function($scope, $location, $window, translation, auth, domaine, $cookies, toastr, $state, AccessRightsService, translatedwords, $q, $translatePartialLoader, $route, $timeout, $translate, _version) {
-   
+
     $scope._version = _version;
     var pc = this;
     var obj = translation.getObjectTranslated();
@@ -24,7 +24,6 @@ angular.module('beeOneWebFrontApp')
 
     $scope.StatesWithoutFarm = ['home', 'gestionprofils', 'groupe', 'profilsfermes', 'ressources_hydriques', 'tb_organisationparcelisation', 'SuiviressourceshydriquesEtat', 'bilan_technique', 'gestiondessocietes', 'gestiondesfermes', 'suiviinterventionsequipements_synthese', 'profile_calibre_data_integration', 'etatdesynthesescroring', 'ajustement_des_calibres'];
 
-
     $scope.changelang = function(lang) {
       $window.localStorage.setItem("lang", lang);
       $translate.use(lang.toLowerCase());
@@ -32,19 +31,20 @@ angular.module('beeOneWebFrontApp')
       translation.getObjectTranslated();
     }
 
-    $scope.loading = false;   
-
+    $scope.loading = false;
 
     //disconnect
     $scope.logout = function() {
       $scope.loading = true;
-      $timeout(function () {             
+      $timeout(function () {
         auth.ClearCredentials();
-        $scope.loading = false; 
+        $scope.loading = false;
       }, 3000);
-      
+
     }
 
-
+    $scope.runTest = function() {
+      console.log('Test button clicked');
+    };
 
   });

--- a/app/scripts/i18n/section/en.json
+++ b/app/scripts/i18n/section/en.json
@@ -221,5 +221,8 @@
   "scoring": "Scoring",
   "parametrage_scoring": "Scoring Settings",
   "baremes": "Scales",
-  "classifications": "Classifications"
+  "classifications": "Classifications",
+  "HEADER": {
+    "TEST": "Test"
+  }
 }

--- a/app/scripts/i18n/section/es.json
+++ b/app/scripts/i18n/section/es.json
@@ -221,5 +221,8 @@
   "scoring": "Scoring",
   "parametrage_scoring": "Scoring Settings",
   "baremes": "Scales",
-  "classifications": "Classifications"
+  "classifications": "Classifications",
+  "HEADER": {
+    "TEST": "Prueba"
+  }
 }

--- a/app/scripts/i18n/section/fr.json
+++ b/app/scripts/i18n/section/fr.json
@@ -254,5 +254,8 @@
   "scoring": "Scoring",
   "parametrage_scoring": "Paramétrage Scoring",
   "bareme": "Barèmes",
-  "classification": "Classifications"
+  "classification": "Classifications",
+  "HEADER": {
+    "TEST": "Test"
+  }
 }

--- a/app/scripts/services/translation.js
+++ b/app/scripts/services/translation.js
@@ -68,6 +68,7 @@ angular.module('beeOneWebFrontApp')
           obj.GestionEquipe = "Gestion des équipes";
           obj.Dernieres_nouveautes = "Latest release";
           obj.new = "new";
+          obj.HEADER = { TEST: "Test" };
         } else if (obj.lang === "ES") {
           obj.Deconnexion = "Cerrar sesión";
           obj.Vousnetespasconnectes = "No estás conectado !!";
@@ -120,6 +121,7 @@ angular.module('beeOneWebFrontApp')
           obj.GestionEquipe = "Gestión de equipos";
           obj.Dernieres_nouveautes = "Últimas novedades";
           obj.new = "nuevo";
+          obj.HEADER = { TEST: "Prueba" };
           obj.Madeby = "Hecho por";
         } else if (obj.lang === "FR" || obj.lang === null) {
           if (obj.lang === null) {
@@ -178,6 +180,7 @@ angular.module('beeOneWebFrontApp')
           obj.GestionEquipe = "Gestion des équipes";
           obj.Dernieres_nouveautes = "Dernières nouveautés";
           obj.new = "new";
+          obj.HEADER = { TEST: "Test" };
         } else if (obj.lang === "AR") {
           obj.Deconnexion = "خروج";
           obj.Vousnetespasconnectes = "!! أنت غير متصل";

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -255,6 +255,16 @@ border-radius: 5px;
   height: 20px;
 }
 
+.test-btn {
+  margin-left: 10px;
+  padding: 4px 8px;
+  background-color: #ffffff;
+  color: #3f51b5;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 .header nav ul {
   list-style: none;
   display: flex;

--- a/app/views/sections/header.html
+++ b/app/views/sections/header.html
@@ -1,23 +1,21 @@
-
-  <div class="header" ng-controller="HeaderCtrl as pc">
-      <div class="logo-header">
-          <img src="../images/beeone_erp_white.svg" alt="Logo">
-      </div>
-      <nav>
-          <ul>
-              <li>
-                  <select ng-model="lang" ng-change="changelang(lang)">
-                      <option value="FR">FR</option>
-                      <option value="EN">EN</option>
-                      <option value="ES">ES</option>
-                  </select>
-              </li>
-              <li>
-                  <a ng-click="logout()"><img src="././images/header/logout.svg" alt="logout"/></a>
-              </li>
-          </ul>
-      </nav>
-      <loading-spinner is-loading="loading" ng-if="loading"></loading-spinner>
-  </div>
-  
-  
+<div class="header" ng-controller="HeaderCtrl as pc">
+    <div class="logo-header">
+        <img src="../images/beeone_erp_white.svg" alt="Logo">
+        <button class="test-btn" ng-click="runTest()">{{ 'HEADER.TEST' | translate }}</button>
+    </div>
+    <nav>
+        <ul>
+            <li>
+                <select ng-model="lang" ng-change="changelang(lang)">
+                    <option value="FR">FR</option>
+                    <option value="EN">EN</option>
+                    <option value="ES">ES</option>
+                </select>
+            </li>
+            <li>
+                <a ng-click="logout()"><img src="././images/header/logout.svg" alt="logout"/></a>
+            </li>
+        </ul>
+    </nav>
+    <loading-spinner is-loading="loading" ng-if="loading"></loading-spinner>
+</div>


### PR DESCRIPTION
## Summary
- add test button next to logo in header
- handle button click with runTest method
- style test button and add translations in English, French, and Spanish

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689f12279edc832da2c933ee3fc0d37d